### PR TITLE
some logic to handle 0 price listings

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -82,17 +82,21 @@ func (pc *pollingClient) poll(ctx context.Context, search clSearch) {
 	if len(result.Listings) > 0 {
 		listingsToSave := []clListing{}
 		for _, l := range result.Listings {
-			p, err := strconv.Atoi(l.Price[1:])
-			if err != nil {
-				fmt.Println("err converting from fn poll():", err)
+			var price int = 0
+			if len(l.Price) > 0 {
+				price, err = strconv.Atoi(l.Price[1:])
+				if err != nil {
+					fmt.Println("err converting from fn poll():", err)
+				}
 			}
+
 			listingsToSave = append(listingsToSave, clListing{
 				DataPID:      l.DataPID,
 				DataRepostOf: l.DataRepostOf,
 				UnixDate:     newUnixDate(l.Date),
 				Title:        l.Title,
 				Link:         l.Link,
-				Price:        p,
+				Price:        price,
 				Hood:         l.Hood,
 			})
 		}


### PR DESCRIPTION
closes #26 

What the problem really was: Some craigslist pages provide no listing price. Typically with goods, it is formatted as a string such as "$100". When converting, the poll function would assume this was customary and slice starting at index 1. When no price was present, this was out of bounds.

It was fixed by adding some extra logic to check if there is a price in the first place.